### PR TITLE
Using ((XXX)) in an arithmetic context

### DIFF
--- a/src/repeat.bash
+++ b/src/repeat.bash
@@ -3,7 +3,7 @@ string_repeat()
     local count="${1}"
     local string="${2}"
 
-    if [[ "${count}" -lt 1 ]]; then
+    if ((count < 1)); then
         return 1
     fi
 

--- a/src/repeat.bash
+++ b/src/repeat.bash
@@ -2,6 +2,7 @@ string_repeat()
 {
     local count="${1}"
     local string="${2}"
+    local i
 
     if ((count < 1)); then
         return 1


### PR DESCRIPTION
Using ((XXX)) in an arithmetic context.

((arg1 OP arg2)) is more clear than the other arithmetic operators: -eq, -ne, -lt, -le for some cases.